### PR TITLE
docs: add README with OctoAcme project management summary and doc links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# OctoAcme Project Management Docs
+
+Welcome to the OctoAcme Project Management documentation hub. This README provides a concise orientation to OctoAcme’s project management approach, links to the full process documents stored in this folder, and guidance on where to raise updates or questions.
+
+OctoAcme runs projects using a structured, iterative lifecycle: Initiation, Planning, Execution, Release, and Retrospective. Initiation focuses on validating business need, defining measurable outcomes (Project One-pager), and aligning stakeholders. Planning breaks approved initiatives into shippable increments, defines a backlog with acceptance criteria, identifies risks and dependencies, and produces a release plan. Execution centers on small, testable work items tracked on the project board and delivered via the PR workflow; releases follow a set of pre-release checks and rollback plans. Retrospectives capture lessons and convert them into actionable backlog items for continuous improvement.
+
+Core personas include Project Managers (coordinate delivery, risks, and stakeholder communication), Product Managers (define outcomes and prioritize the backlog), Developers (implement features and tests), QA/Testers (validate acceptance criteria), and Stakeholders (provide domain context and approvals). Each role has explicit responsibilities to ensure clear ownership and smoother handoffs across lifecycle phases.
+
+Communication and quality practices are baked into the process: a regular cadence of daily standups, PM–PdM syncs, sprint demos, and monthly stakeholder updates; formal templates for weekly status and incident communications; and a layered QA strategy (unit, integration, E2E smoke tests, security scanning in CI, and manual acceptance testing when needed). Use the links below to read the detailed process docs, and if you want to suggest changes use the process update issue template in .github/ISSUE_TEMPLATE/.
+
+## Process Documentation Index
+
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning Guide](./octoacme-project-planning.md)
+- [Execution & Tracking Guide](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](./octoacme-roles-and-personas.md)
+
+---
+
+If you have feedback or would like to propose edits, open an issue using the "Add Content to Project Management Process Docs" template located under .github/ISSUE_TEMPLATE/.


### PR DESCRIPTION
Adds docs/README.md with a concise overview of OctoAcme project management processes and direct links to all process docs.\n\nThis PR addresses the request in Issue #2 and provides a single onboarding entrypoint for the docs.\n\nCloses #2